### PR TITLE
Fix paths in library_list and category_menu.

### DIFF
--- a/plugins/content_types/category_menu.inc
+++ b/plugins/content_types/category_menu.inc
@@ -39,7 +39,7 @@ function ding_content_category_menu_content_type_render($subtype, $conf, $panel_
   $items = array(l(t('All categories'), $base . '/all', $options));
 
   $vocabulary = taxonomy_vocabulary_machine_name_load('category');
-  $terms = taxonomy_get_tree($vocabulary->vid);
+  $terms = taxonomy_get_tree($vocabulary->vid, 0, NULL, TRUE);
 
   foreach ($terms as $term) {
     if ($selected_term && $selected_term->tid == $term->tid) {
@@ -48,7 +48,8 @@ function ding_content_category_menu_content_type_render($subtype, $conf, $panel_
     else {
       $options = array();
     }
-    $items[] = l($term->name, $base . '/' . $term->tid, $options);
+    $uri = entity_uri('taxonomy_term', $term);
+    $items[] = l($term->name, $uri['path'], $options);
   }
   $block->content = theme('item_list', array('items' => $items));
 
@@ -65,8 +66,8 @@ function ding_content_category_menu_content_type_edit_form($form, &$form_state) 
     '#type' => 'select',
     '#title' => t('Type of list to link to'),
     '#options' => array(
-      'news' => t('News'),
-      'events' => t('Events'),
+      'news-category' => t('News'),
+      'event-category' => t('Events'),
     ),
     '#default_value' => !empty($conf['type']) ? $conf['type'] : 'news',
     '#required' => TRUE,

--- a/plugins/content_types/library_list.inc
+++ b/plugins/content_types/library_list.inc
@@ -47,7 +47,7 @@ function ding_content_library_list_content_type_render($subtype, $conf, $panel_a
   }
 
   uasort($nodes, 'ding_content_library_list_sort_title');
-  $items = array($conf['type'] . $suffix => t('All libraries'));
+  $items = array($conf['type'] . $suffix . '/all' => t('All libraries'));
 
   foreach ($nodes as $node) {
     $uri = entity_uri('node', $node);
@@ -114,8 +114,8 @@ function ding_content_library_list_content_type_edit_form($form, &$form_state) {
     '#type' => 'select',
     '#title' => t('Type of list to link to'),
     '#options' => array(
-      'news' => t('News'),
-      'events' => t('Events'),
+      'news-category' => t('News'),
+      'event-category' => t('Events'),
     ),
     '#default_value' => !empty($conf['type']) ? $conf['type'] : 'news',
     '#required' => TRUE,


### PR DESCRIPTION
- Use the drupal aliased paths instead of path/term_id.
- Use event-category/ instead of events/
- Use news-category/ instead of news/